### PR TITLE
Resolve race condition by ensuring that `op=connected` has been received before sending a new subscribe event

### DIFF
--- a/ParseLiveQuery/src/main/java/com/parse/ParseLiveQueryClientImpl.java
+++ b/ParseLiveQuery/src/main/java/com/parse/ParseLiveQueryClientImpl.java
@@ -88,6 +88,7 @@ import static com.parse.Parse.checkInit;
         Subscription<T> subscription = new Subscription<>(requestId, query);
         subscriptions.append(requestId, subscription);
 
+        // TODO: differentiate between state=CONNECTED, vs received op=connected response
         if (inAnyState(WebSocketClient.State.CONNECTED)) {
             sendSubscription(subscription);
         } else if (userInitiatedDisconnect) {

--- a/ParseLiveQuery/src/main/java/com/parse/ParseLiveQueryClientImpl.java
+++ b/ParseLiveQuery/src/main/java/com/parse/ParseLiveQueryClientImpl.java
@@ -38,6 +38,7 @@ import static com.parse.Parse.checkInit;
     private WebSocketClient webSocketClient;
     private int requestIdCount = 1;
     private boolean userInitiatedDisconnect = false;
+    private boolean hasReceivedConnected = false;
 
     /* package */ ParseLiveQueryClientImpl() {
         this(getDefaultUri());
@@ -88,8 +89,7 @@ import static com.parse.Parse.checkInit;
         Subscription<T> subscription = new Subscription<>(requestId, query);
         subscriptions.append(requestId, subscription);
 
-        // TODO: differentiate between state=CONNECTED, vs received op=connected response
-        if (inAnyState(WebSocketClient.State.CONNECTED)) {
+        if (isConnected()) {
             sendSubscription(subscription);
         } else if (userInitiatedDisconnect) {
             Log.w(LOG_TAG, "Warning: The client was explicitly disconnected! You must explicitly call .reconnect() in order to process your subscriptions.");
@@ -151,18 +151,21 @@ import static com.parse.Parse.checkInit;
             webSocketClient.close();
         }
 
+        userInitiatedDisconnect = false;
+        hasReceivedConnected = false;
         webSocketClient = webSocketClientFactory.createInstance(webSocketClientCallback, uri);
         webSocketClient.open();
-        userInitiatedDisconnect = false;
     }
 
     @Override
     public void disconnect() {
         if (webSocketClient != null) {
-            userInitiatedDisconnect = true;
             webSocketClient.close();
             webSocketClient = null;
         }
+
+        userInitiatedDisconnect = true;
+        hasReceivedConnected = false;
     }
 
     @Override
@@ -184,6 +187,10 @@ import static com.parse.Parse.checkInit;
     private WebSocketClient.State getWebSocketState() {
         WebSocketClient.State state = webSocketClient == null ? null : webSocketClient.getState();
         return state == null ? WebSocketClient.State.NONE : state;
+    }
+
+    private boolean isConnected() {
+        return hasReceivedConnected && inAnyState(WebSocketClient.State.CONNECTED);
     }
 
     private boolean inAnyState(WebSocketClient.State... states) {
@@ -220,6 +227,7 @@ import static com.parse.Parse.checkInit;
 
             switch (rawOperation) {
                 case "connected":
+                    hasReceivedConnected = true;
                     dispatchConnected();
                     Log.v(LOG_TAG, "Connected, sending pending subscription");
                     for (int i = 0; i < subscriptions.size(); i++) {
@@ -371,6 +379,7 @@ import static com.parse.Parse.checkInit;
         return new WebSocketClient.WebSocketClientCallback() {
             @Override
             public void onOpen() {
+                hasReceivedConnected = false;
                 Log.v(LOG_TAG, "Socket opened");
                 ParseUser.getCurrentSessionTokenAsync().onSuccessTask(new Continuation<String, Task<Void>>() {
                     @Override
@@ -406,12 +415,14 @@ import static com.parse.Parse.checkInit;
             @Override
             public void onClose() {
                 Log.v(LOG_TAG, "Socket onClose");
+                hasReceivedConnected = false;
                 dispatchDisconnected();
             }
 
             @Override
             public void onError(Throwable exception) {
                 Log.e(LOG_TAG, "Socket onError", exception);
+                hasReceivedConnected = false;
                 dispatchSocketError(exception);
             }
 

--- a/ParseLiveQuery/src/test/java/com/parse/TestParseLiveQueryClient.java
+++ b/ParseLiveQuery/src/test/java/com/parse/TestParseLiveQueryClient.java
@@ -1,5 +1,6 @@
 package com.parse;
 
+import org.assertj.core.api.Assertions;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.After;
@@ -80,6 +81,42 @@ public class TestParseLiveQueryClient {
     public void tearDown() throws Exception {
         ParseCorePlugins.getInstance().reset();
         ParsePlugins.reset();
+    }
+
+    @Test
+    public void testSubscribeBetweenSocketConnectAndConnectResponse() throws Exception {
+        ParseQuery<ParseObject> queryA = ParseQuery.getQuery("objA");
+        ParseQuery<ParseObject> queryB = ParseQuery.getQuery("objB");
+        clearConnection();
+
+        // This will trigger connectIfNeeded(), which calls reconnect()
+        SubscriptionHandling<ParseObject> subA = parseLiveQueryClient.subscribe(queryA);
+
+        verify(webSocketClient, times(1)).open();
+        verify(webSocketClient, never()).send(anyString());
+
+        // Now the socket is open
+        webSocketClientCallback.onOpen();
+        when(webSocketClient.getState()).thenReturn(WebSocketClient.State.CONNECTED);
+        // and we send op=connect
+        verify(webSocketClient, times(1)).send(contains("\"op\":\"connect\""));
+
+        // Now if we subscribe to queryB, we SHOULD NOT send the subscribe yet, until we get op=connected
+        SubscriptionHandling<ParseObject> subB = parseLiveQueryClient.subscribe(queryB); // TODO: fix this state
+        verify(webSocketClient, never()).send(contains("\"op\":\"subscribe\""));
+
+        // on op=connected, _then_ we should send both subscriptions
+        webSocketClientCallback.onMessage(createConnectedMessage().toString());
+        verify(webSocketClient, times(2)).send(contains("\"op\":\"subscribe\""));
+
+        // 1. Subscribe to queryA
+        //    - it is not connected yet, so it will trigger reconnect.
+        // 2. Socket opens & connects;  initiate op=connect
+        // 3. subscribe to queryB
+        //    - SOCKET is connected, but we haven't received op=connected yet.
+        //    - BUG: it will call sendSubscription now
+        // 4. Server responds to #2 with op=connected
+        // 5. On op=connected, we replay pending subscriptions, including the one that was already sent in #3
     }
 
     @Test
@@ -457,6 +494,11 @@ public class TestParseLiveQueryClient {
 
         assertEquals(originalParseObject.getClassName(), newParseObject.getClassName());
         assertEquals(originalParseObject.getObjectId(), newParseObject.getObjectId());
+    }
+
+    private void clearConnection() {
+        webSocketClient = null;
+        webSocketClientCallback = null;
     }
 
     private void reconnect() {


### PR DESCRIPTION
`ParseLiveQueryClient.subscribe()` checks if the socket state is "CONNECTED" before sending the subscribe event.  If it's not, it triggers a reconnect.

The problem is that when the socket connects, we also send the `op=connect` event to the server, and wait for the server to respond with `op=connected`.  At the time of `op=connected`, we then send any pending subscribe messages.

If a subscribe request comes in _after_ the socket is connected, but _before_ the `op=connected` message comes from the server, we will end up with that subscription duplicated, and we'll receive duplicated events as a result.