### PR TITLE
Change package name

### DIFF
--- a/ParseLiveQuery/src/main/AndroidManifest.xml
+++ b/ParseLiveQuery/src/main/AndroidManifest.xml
@@ -7,6 +7,6 @@
   ~ LICENSE file in the root directory of this source tree. An additional grant
   ~ of patent rights can be found in the PATENTS file in the same directory.
   -->
-<manifest package="com.parse">
+<manifest package="com.parse.livequery">
     <application />
 </manifest>

--- a/ParseLiveQuery/src/test/java/com/parse/TestParseLiveQueryClient.java
+++ b/ParseLiveQuery/src/test/java/com/parse/TestParseLiveQueryClient.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import com.parse.livequery.BuildConfig;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = 21)


### PR DESCRIPTION
To avoid duplicated BuildConfig with the Parse SDK.
Related to #60 & https://github.com/parse-community/Parse-SDK-Android/issues/671