### PR TITLE
fixed name change of bolts dependency

### DIFF
--- a/ParseLiveQuery/build.gradle
+++ b/ParseLiveQuery/build.gradle
@@ -24,7 +24,7 @@ android {
 }
 
 dependencies {
-    api "com.github.parse-community.Parse-SDK-Android:parse:1.24.1"
+    api "com.github.parse-community.Parse-SDK-Android:parse:1.24.2"
     api "com.squareup.okhttp3:okhttp:3.14.4"
 
     testImplementation "org.robolectric:robolectric:3.3.1"

--- a/ParseLiveQuery/src/main/java/com/parse/livequery/ParseLiveQueryClientImpl.java
+++ b/ParseLiveQuery/src/main/java/com/parse/livequery/ParseLiveQueryClientImpl.java
@@ -22,8 +22,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 
-import bolts.Continuation;
-import bolts.Task;
+import com.parse.boltsinternal.Continuation;
+import com.parse.boltsinternal.Task;
 import okhttp3.OkHttpClient;
 
 class ParseLiveQueryClientImpl implements ParseLiveQueryClient {

--- a/ParseLiveQuery/src/test/java/com/parse/TestParseLiveQueryClient.java
+++ b/ParseLiveQuery/src/test/java/com/parse/TestParseLiveQueryClient.java
@@ -24,7 +24,7 @@ import org.robolectric.util.Transcript;
 import java.io.IOException;
 import java.net.URI;
 
-import bolts.Task;
+import com.parse.boltsinternal.Task;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;


### PR DESCRIPTION
The name of the internalized bolts dependency has been changed from `bolts` to `boltsinternal` with https://github.com/parse-community/Parse-SDK-Android/pull/1033.

This PR reflects these changes in the LiveQuery SDK.