### PR TITLE
Rollback OkHttp version (#113)

### DIFF
--- a/ParseLiveQuery/build.gradle
+++ b/ParseLiveQuery/build.gradle
@@ -25,7 +25,9 @@ android {
 
 dependencies {
     api "com.github.parse-community.Parse-SDK-Android:parse:1.24.2"
-    api "com.squareup.okhttp3:okhttp:3.14.4"
+
+    // Note: Don't update past 3.12.x, as it sets the minSdk to Android 5.0
+    api "com.squareup.okhttp3:okhttp:3.12.10"
 
     testImplementation "org.robolectric:robolectric:3.3.1"
     testImplementation "org.skyscreamer:jsonassert:1.5.0"


### PR DESCRIPTION
OkHttp v3.13 bumps minSdkVersion to 21 (Android 5.0). To maintain maximum
compatibility, we can stick to OkHttp v3.12.