### PR TITLE
feat: Send client key in the connect operation

### DIFF
--- a/ParseLiveQuery/src/main/java/com/parse/livequery/ConnectClientOperation.java
+++ b/ParseLiveQuery/src/main/java/com/parse/livequery/ConnectClientOperation.java
@@ -7,10 +7,12 @@ class ConnectClientOperation extends ClientOperation {
 
     private final String applicationId;
     private final String sessionToken;
+    private final String clientKey;
 
-    ConnectClientOperation(String applicationId, String sessionToken) {
+    ConnectClientOperation(String applicationId, String sessionToken, String clientKey) {
         this.applicationId = applicationId;
         this.sessionToken = sessionToken;
+        this.clientKey = clientKey;
     }
 
     @Override
@@ -19,6 +21,7 @@ class ConnectClientOperation extends ClientOperation {
         jsonObject.put("op", "connect");
         jsonObject.put("applicationId", applicationId);
         jsonObject.put("sessionToken", sessionToken);
+        jsonObject.put("clientKey", clientKey);
         return jsonObject;
     }
 }

--- a/ParseLiveQuery/src/main/java/com/parse/livequery/ParseLiveQueryClientImpl.java
+++ b/ParseLiveQuery/src/main/java/com/parse/livequery/ParseLiveQueryClientImpl.java
@@ -386,7 +386,7 @@ class ParseLiveQueryClientImpl implements ParseLiveQueryClient {
                     @Override
                     public Task<Void> then(Task<String> task) throws Exception {
                         String sessionToken = task.getResult();
-                        return sendOperationAsync(new ConnectClientOperation(applicationId, sessionToken));
+                        return sendOperationAsync(new ConnectClientOperation(applicationId, sessionToken, clientKey));
                     }
                 }).continueWith(new Continuation<Void, Void>() {
                     public Void then(Task<Void> task) {


### PR DESCRIPTION
For parse setups that use a client key, the live query client will never connect appropriately as the android library doesn't pass in the client key.

See: https://github.com/parse-community/ParseLiveQuery-iOS-OSX/pull/136